### PR TITLE
do not generate class names with hyphens

### DIFF
--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -337,7 +337,7 @@ class ModelClass(Model):
 
     @staticmethod
     def _tablename_to_classname(tablename, inflect_engine):
-        camel_case_name = ''.join(part[:1].upper() + part[1:] for part in tablename.split('_'))
+        camel_case_name = ''.join(part[:1].upper() + part[1:] for part in re.split(r'_|-', tablename))
         return inflect_engine.singular_noun(camel_case_name) or camel_case_name
 
     def _add_attribute(self, attrname, value):


### PR DESCRIPTION
A MS SQL database can have hyphens in table names which is bad for python classnames